### PR TITLE
商品編集機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :user_confirmation, only: [:edit, :update]
   # application_controllerではなく、items_controllerni記述する。
   # only: [:new]だけでなく、:createも記述することで、不正にアクセスした場合のセキュリティもカバーすることができる
 
@@ -24,11 +25,28 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+    redirect_to root_path unless current_user.id == @item.user_id
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path
+    else
+      render :edit
+    end
+  end
 
   private
 
   def item_params
     params.require(:item).permit(:title, :description, :image, :category_id, :delivery_day_id, :delivery_fee_id, :prefecture_id,
                                  :item_status_id, :price).merge(user_id: current_user.id)
+  end
+
+  def user_confirmation
+    #redirect_to root_path unless current_user == @item.user
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,5 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :user_confirmation, only: [:edit, :update]
   # application_controllerではなく、items_controllerni記述する。
   # only: [:new]だけでなく、:createも記述することで、不正にアクセスした場合のセキュリティもカバーすることができる
 
@@ -46,7 +45,4 @@ class ItemsController < ApplicationController
                                  :item_status_id, :price).merge(user_id: current_user.id)
   end
 
-  def user_confirmation
-    #redirect_to root_path unless current_user == @item.user
-  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update]
   # application_controllerではなく、items_controllerni記述する。
   # only: [:new]だけでなく、:createも記述することで、不正にアクセスした場合のセキュリティもカバーすることができる
 
@@ -21,16 +22,13 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
     redirect_to root_path unless current_user.id == @item.user_id
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path
     else
@@ -43,6 +41,10 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:title, :description, :image, :category_id, :delivery_day_id, :delivery_fee_id, :prefecture_id,
                                  :item_status_id, :price).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,7 +1,9 @@
+<%# cssは商品出品のものを併用しています。
+app/assets/stylesheets/items/new.css %>
+
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
-
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
@@ -21,7 +23,6 @@
         <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
-
     <div class="new-items">
       <div class="weight-bold-text">
         商品名
@@ -40,13 +41,11 @@
     <div class="items-detail">
       <div class="weight-bold-text">商品の詳細</div>
       <div class="form">
-
         <div class="weight-bold-text">
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
         <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
-        
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
@@ -60,20 +59,17 @@
         <span>配送について</span>
         <a class="question" href="#">?</a>
       </div>
-
       <div class="form">
         <div class="weight-bold-text">
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
         <%= f.collection_select(:delivery_fee_id, DeliveryFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
-        
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
         <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
-        
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
@@ -106,8 +102,8 @@
           <span>販売利益</span>
           <span>
             <span id='profit'></span>円
+          </span>
         </div>
-        </span>
       </div>
     </div>
 
@@ -132,8 +128,8 @@
     <%# /注意書き %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
-      <%= f.submit "出品する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
+      <%= f.submit "変更する", class:"sell-btn" %>
+      <%=link_to 'もどる', item_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
 
     <% if user_signed_in? %>
       <% if current_user.id == @item.user_id %>
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
# What
商品編集機能の実装

# Why
出品した商品の内容を編集できるようにするため。


- ログイン状態の出品者は、商品情報編集ページに遷移できる
https://gyazo.com/bcbd026dced820c8b86476db7403c716

- 正しく情報を記入すると、商品の情報を編集できる
https://gyazo.com/22ea48d0c76bd7b12fa1e8c2f5426468

- 入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される
https://gyazo.com/d4aed2501f9f5bcb04463c34ffecb081

- 何も編集せずに更新をしても画像無しの商品にならない
https://gyazo.com/d63ea7ea84f027966444d1fa99c3ea36

- ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する
https://gyazo.com/80506229a5a09d49a0d389116cde7c23

- ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する
https://gyazo.com/58fb3f194c059b9c9a9d04dc0027ea49

- 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される
https://gyazo.com/e68055a56be42fdf94ab217e6c59015e
